### PR TITLE
Owned-Admins Query Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Ideally there shouldn't be much to install, but I've included a requirements.txt
 
 ### Neo4j Creds
 
-Neo4j credentials can be hardcoded at the beginning of the script *OR* they can be provided as CLI. If both areas are left blank, you will be prompted for the uname/password.
+Neo4j credentials can be hardcoded at the beginning of the script, they can be provided as CLI arguments, or stored as environment variables. If either parameter  is left blank, you will be prompted for the uname/password. To use environment variables, it is probably easiest to add a line (e.g., `export NEO4J_USERNAME='neo4j'`) within *~/.bashrc* or *~/.zshrc*  to store the username since it isn't really sensitive. The database password can be set within your shell's tab prior to running Max. Adding a space before the export command should prevent it from appearing within history.
+
+```bash
+ export NEO4J_PASSWORD='bloodhound' # Notice whitespace before 'export'
+python3 max.py {module} {args}
+
+```
 
 ```
 python3 max.py -u neo4j -p neo4j {module} {args}

--- a/max.py
+++ b/max.py
@@ -329,8 +329,8 @@ def get_info(args):
         query = queries["group-members"]["query"].format(gname=args.groupmems.upper().strip())
         cols = queries["group-members"]["columns"]
     elif (args.ownedadmins):
-        query = queries.get("ownedadmins", {}).get("query", "")
-        cols = queries.get("ownedadmins", {}).get("columns", [""])
+        query = queries["ownedadmins"]["query"]
+        cols = queries["ownedadmins"]["columns"]
     elif (args.path != ""):
         start = args.path.split(',')[0].strip().upper()
         end = args.path.split(',')[1].strip().upper()

--- a/max.py
+++ b/max.py
@@ -236,7 +236,7 @@ def get_info(args):
             "columns" : ["Path"]
         },
         "ownedadmins" : {
-            "query": "match p=(u:User {owned: True})-[r:AdminTo|MemberOf*1..]->(c:Computer) return c.name, \"AdministratedBy\", u.name order by c",
+            "query": "match (u:User {owned: True})-[r:AdminTo|MemberOf*1..]->(c:Computer) return c.name, \"AdministratedBy\", u.name order by c, u",
             "columns": ["ComputerName", "HasAdmin", "UserName"]
         }
     }

--- a/wiki/get-info.md
+++ b/wiki/get-info.md
@@ -98,4 +98,5 @@ python3 max.py get-info --owned-admins
 COMP1.DOMAIN.LOCAL - AdministratedBy - USER1@DOMAIN.LOCAL
 COMP2.DOMAIN.LOCAL - AdministratedBy - USER1@DOMAIN.LOCAL
 COMP2.DOMAIN.LOCAL - AdministratedBy - USER2@DOMAIN.LOCAL
+...
 ```

--- a/wiki/get-info.md
+++ b/wiki/get-info.md
@@ -30,6 +30,7 @@ There are a few things you can extract with this module:
 * `path` will return the full shortest path between two input nodes, `paths-all` will return all the shortest paths
 * `hvt-paths` will return all paths to HVTs originating from an input node
 * `owned-paths` will return all paths to HVTs originating from an input node
+* `owned-admins` will return all computers to which owned users are admins 
 * `-l` apply column labels as a header. All queries with `get-info` do not return column headers (like "UserName","ComputerName","Description",etc) by default with the query
 * `-e/--enabled` returns only the enabled users from the applicable query (only working for `--users` and `--passnotreq`)
 * `d/delim` Is a flag where a new output delimeter can be set to separate outputs. Default is `output1 - output2` with the "-" being the changable delimeter. Doesn't apply to path outputs
@@ -90,4 +91,11 @@ ADMINISTRATOR@DOMAIN.LOCAL - MemberOf -> ADMINISTRATORS@DOMAIN.LOCAL - WriteDacl
 ADMINISTRATOR@DOMAIN.LOCAL - MemberOf -> ADMINISTRATORS@DOMAIN.LOCAL - AllExtendedRights -> DOMAIN.LOCAL
 ADMINISTRATOR@DOMAIN.LOCAL - MemberOf -> ADMINISTRATORS@DOMAIN.LOCAL - WriteOwner -> DOMAIN.LOCAL
 
+```
+```python
+python3 max.py get-info --owned-admins
+
+COMP1.DOMAIN.LOCAL - AdministratedBy - USER1@DOMAIN.LOCAL
+COMP2.DOMAIN.LOCAL - AdministratedBy - USER1@DOMAIN.LOCAL
+COMP2.DOMAIN.LOCAL - AdministratedBy - USER2@DOMAIN.LOCAL
 ```

--- a/wiki/get-info.md
+++ b/wiki/get-info.md
@@ -92,7 +92,7 @@ ADMINISTRATOR@DOMAIN.LOCAL - MemberOf -> ADMINISTRATORS@DOMAIN.LOCAL - AllExtend
 ADMINISTRATOR@DOMAIN.LOCAL - MemberOf -> ADMINISTRATORS@DOMAIN.LOCAL - WriteOwner -> DOMAIN.LOCAL
 
 ```
-```python
+```
 python3 max.py get-info --owned-admins
 
 COMP1.DOMAIN.LOCAL - AdministratedBy - USER1@DOMAIN.LOCAL

--- a/wiki/pet-max.md
+++ b/wiki/pet-max.md
@@ -1,6 +1,6 @@
 ## Module: pet-max
 
-Its adorable. That is all.
+It's adorable. That is all.
 
 "Arguably the most important contribution to this project" - me
 


### PR DESCRIPTION
++ owned-admins query which returns a list of all computers owned users are admins to either directly  or through unrolled group membership. I find it useful for quick wins / movement that might get missed within Bloodhound's GUI if they aren't included within shortest paths. This can probably be improved by narrowing the results down to distinct computer names to clean up output.
++ Example of owned-admins output within wiki/get-info.md
++ Grammar fix because I'm annoying
++ Option to store neo4j creds in environment variables so they aren't hard-coded. NEO4J_USERNAME can easily be put into a .bashrc or similar since it isn't really sensitive, NEO4J_PASSWORD can be exported within whichever shell / tab max will be run in. Bonus if using a space before export keyword so the command isn't recorded in history. Defaults still remain neo4j / bloodhound
