### PR TITLE
Potfiles are not passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ python3 max.py add-spns -i getuserspns-raw-output.txt
 
 DPAT
 ```
-python3 max.py dpat -n ~/client/ntds.dit -p ~/.hashcat/hashcat.potfile -o ouputdir --html --sanitize
+python3 max.py dpat -n ~/client/ntds.dit -c ~/.hashcat/hashcat.potfile -o ouputdir --html --sanitize
 ```
 
 Pet max


### PR DESCRIPTION
A small correction in the DPAT module portion of `README.md`