### PR TITLE
Add DPAT subreport for enabled cracked accounts

### DIFF
--- a/max.py
+++ b/max.py
@@ -892,6 +892,10 @@ def dpat_func(args):
             'label' : "All User Accounts Cracked"
         },
         {
+            "query" : "MATCH p=(u:User {cracked:true}) WHERE u.enabled = TRUE RETURN DISTINCT u.enabled,u.ntds_uname,u.password,u.nt_hash",
+            "label" : "Enabled User Accounts Cracked"
+        },
+        {
             'query' : "MATCH p=(u:User {cracked:true})-[r:MemberOf*1..]->(g:Group {highvalue:true}) RETURN DISTINCT u.enabled,u.ntds_uname,u.password,u.nt_hash",
             'label' : "High Value User Accounts Cracked"
         },


### PR DESCRIPTION
This PR just adds a cypher query to create a new report listing cracked passwords on enabled accounts only.

This can be useful to quickly filter out weak passwords that are not exploitable due to the account being disabled.