### PR TITLE
better support for LM hashes in potfiles

### DIFF
--- a/max.py
+++ b/max.py
@@ -718,9 +718,9 @@ def dpat_map_users(args, users, potfile):
             if nt_hash in potfile:
                 cracked_bool = 'true'
                 password = potfile[nt_hash]
-            elif lm_hash != "aad3b435b51404eeaad3b435b51404ee" and lm_hash in potfile:
+            elif lm_hash != "aad3b435b51404eeaad3b435b51404ee" and lm_hash[:16] in potfile and lm_hash[16:] in potfile:
                 cracked_bool = 'true'
-                password = potfile[lm_hash]
+                password = potfile[lm_hash[:16]] + potfile[lm_hash[16:]]
 
             if password != None:
                 if "$HEX[" in password:
@@ -811,7 +811,7 @@ def dpat_func(args):
                             continue
                         line = line.split(":")
 
-                        if len(line[0]) != 32:
+                        if len(line[0]) not in [16, 32]:
                             continue
 
                         potfile[line[0]] = line[1]


### PR DESCRIPTION
John & Hashcat split LM hashes into two 16 hex char hashes (as per the LM algorithm) in their potfiles. This adds support for those hashes. A workaround for this in the meantime is the following, since it joins the two LM hashes and their respective passwords:
```bash
hashcat --show -m 3000 <ntds> > temp.pot
python3 max.py dpat -n <ntds> -c ./temp.pot [args]
```