### PR TITLE
Add optional environment variables for Neo4J url/uri

### DIFF
--- a/max.py
+++ b/max.py
@@ -21,9 +21,9 @@ except ImportError:
 from itertools import zip_longest
 
 
-# option to hardcode URL & URI
-global_url = "http://127.0.0.1:7474"
-global_uri = "/db/data/transaction/commit"
+# option to hardcode URL & URI or put them in environment variables, these will be used for neo4j database "default" location
+global_url = "http://127.0.0.1:7474" if (not os.environ.get('NEO4J_URL', False)) else os.environ['NEO4J_URL']
+global_uri = "/db/data/transaction/commit" if (not os.environ.get('NEO4J_URI', False)) else os.environ['NEO4J_URI']
 
 # option to hardcode creds or put them in environment variables, these will be used as the username and password "defaults"
 global_username = 'neo4j' if (not os.environ.get('NEO4J_USERNAME', False)) else os.environ['NEO4J_USERNAME']


### PR DESCRIPTION
The PR adds the option to set environment variables NEO4J_URL and NEO4J_URI to bypass default localhost database location.